### PR TITLE
added ip app config variable to allow usage with haproxy/Openshift

### DIFF
--- a/bin/webserver.js
+++ b/bin/webserver.js
@@ -6,6 +6,7 @@ var app = require('../app'),
     io = require('socket.io')(http),
     crypto = require('crypto'),
     port = config.port || process.env.PORT || 3000,
+    ip = config.ip || process.env.IP || "127.0.0.1",
     redis_client = app.get('redis_client'),
     ObjectId = require('mongodb').ObjectID,
     redis_subscriber;
@@ -38,7 +39,7 @@ if (config.redis.active) {
     });
 }
 
-var server = http.listen(port, function() {
+var server = http.listen(port, ip, function() {
     if (config.gid) process.setgid(config.gid);
     if (config.uid) process.setuid(config.uid);
     console.log(" _____                         _     ___ _____ \n" + "|_   _|                       | |   |_  /  ___|\n" + "  | | __ _ _ __ __ _  ___ ___ | |_    | \\ `--. \n" + "  | |/ _` | '__/ _` |/ __/ _ \\| __|   | |`--. \\\n" + "  | | (_| | | | (_| | (_| (_) | |_/\\__/ /\\__/ /\n" + "  \\_/\\__,_|_|  \\__,_|\\___\\___/ \\__\\____/\\____/ \n");

--- a/config.js
+++ b/config.js
@@ -1,5 +1,6 @@
 var config = {
     "port": "3000",
+    "ip" : "127.0.0.1",
     "gid": "",
     "uid": "",
     "protocol": "http",

--- a/modules/lang/block.js
+++ b/modules/lang/block.js
@@ -25,7 +25,9 @@ module.exports = function(app) {
                     lang_list_html: ''
                 },
                 langs_html = '';
-            var host = req.get('host').replace(new RegExp('^' + default_lng + '\.'), '').replace(new RegExp('^' + lng + '\.'), '');
+
+            var host = typeof req.get('host') === 'undefined' ? app.get('config').ip : req.get('host').replace(new RegExp('^' + default_lng + '\.'), '').replace(new RegExp('^' + lng + '\.'), '');
+
             for (var i = 0; i < app.get('config').locales.avail.length; i++) {
                 var _host = host;
                 if (app.get('config').locales.avail[i] != default_lng) _host = app.get('config').locales.avail[i] + '.' + host;


### PR DESCRIPTION
I added Taracotjs as the CMS for my site that is hosted on Openshift. It is load balanced with haproxy and that required a few additions to the base code in order for it to eventually run successfully. The change in config.json is to add a new config variable that collects the IP of the host. On webserver.js, that host is passed through as a parameter in the listen method call. Finally, on the lang/block module, I learned that there was an error caused by haproxy because req.get('host') was undefined. I added a ternary operator there to pull the config file IP if the host is undefined